### PR TITLE
Added postgresql-client Dockerfile

### DIFF
--- a/lib/postgresql-client/Dockerfile
+++ b/lib/postgresql-client/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.7
+
+RUN set -ex \
+    \
+    && apk add --no-cache \
+        bash \
+        bash-completion \
+        postgresql-client \
+        tzdata \
+    && cp /usr/share/zoneinfo/Europe/Madrid /etc/localtime
+
+ENTRYPOINT [ "psql" ]

--- a/lib/postgresql-client/README.md
+++ b/lib/postgresql-client/README.md
@@ -1,0 +1,30 @@
+# siose-innova/postgresql-client
+
+PostgreSQL client utilities including `psql` CLI interface, `pg_dump`and `pg_restore`.
+
+## Usage examples
+
+Start a new `psql` session on database `siose2005` located in a PostgreSQL container called `siose2005-mf2` over network `siose-net`:  
+  
+```
+docker run -it --rm --network siose-net siose-innova/postgresql-client posgresql://username@siose2005-mf2/siose2005
+```  
+  
+Dump database `siose2005` located in a PostgreSQL container called `siose2005-mf2` over network `siose-net`. Create dump in your host's present working directory using directory format and three parallel processes:  
+  
+```
+docker run -it --rm --network siose-net -v $PWD:/var/data/dump --entrypoint "/usr/bin/pg_dump" siose-innova/postgresql-client -d posgresql://username:passwd@siose2005-mf2/siose2005 -Fd -j 3 -O -x -f /var/data/dump
+```  
+  
+Use a database dump, stored in your host's present working directory, to restore into database `siose2005` located in a PostgreSQL container called `siose2005-mf2` over network `siose-net`. Since you are dealing with a dump in directory format, run restore using three parallel processes:  
+  
+```
+docker run -it --rm --network siose-net -v $PWD:/var/data/dump --entrypoint "/usr/bin/pg_restore" siose-innova/postgresql-client -d postgresql://username:passwd@siose2005-mf2/siose2005 -j 3 -O -x /var/data/dump
+```  
+  
+Start a new `bash` shell that gets you access to network `siose-net`:  
+  
+```
+docker run -it --rm --network siose-net --entrypoint "/bin/bash" siose-innova/postgresql-client
+```  
+  


### PR DESCRIPTION
New `siose-innova/postgresql-client` image based upon Alpine Linux 3.7.  
Provides `psql` CLI as default entry point and includes several other PostgreSQL client utilities such as `pg_dump` and `pg_restore`. See https://pkgs.alpinelinux.org/contents?branch=v3.7&name=postgresql-client&arch=x86_64&repo=main for details.  
It also provides `bash` so that an instance of this image may be run as an interactive shell for convenience.  
Compiled image is less than 16MB in size.